### PR TITLE
ActiveSupport cattr_accessor and cattr_writer take a block, your ver does not

### DIFF
--- a/lib/extlib/class.rb
+++ b/lib/extlib/class.rb
@@ -54,7 +54,7 @@ class Class
         end
       RUBY
     end
-  end
+  end unless Class.respond_to?(:cattr_reader)
 
   # Defines class-level (and optionally instance-level) attribute writer.
   #
@@ -84,7 +84,7 @@ class Class
         RUBY
       end
     end
-  end
+  end unless Class.respond_to?(:cattr_writer)
 
   # Defines class-level (and optionally instance-level) attribute accessor.
   #
@@ -96,7 +96,7 @@ class Class
   def cattr_accessor(*syms)
     cattr_reader(*syms)
     cattr_writer(*syms)
-  end
+  end unless Class.respond_to?(:cattr_accessor)
 
   # Defines class-level inheritable attribute reader. Attributes are available to subclasses,
   # each subclass has a copy of parent's attribute.


### PR DESCRIPTION
ActiveSupport `cattr_accessor` and `cattr_writer` take a block, your ver does not.  This breaks rails when it uses these methods with a block to set a default value.  One outcome is that `default_charset` is not set in `ActionDispatch::Response` and the Content-Type header has a blank value for charset.

You might consider requiring `active_support/core_ext/class/attribute_accessors`
