### PR TITLE
Block instance reader creation by referencing :instance_reader

### DIFF
--- a/lib/extlib/class.rb
+++ b/lib/extlib/class.rb
@@ -112,7 +112,7 @@ class Class
   #   moving on). In particular, this makes the return value of this function
   #   less useful.
   def class_inheritable_reader(*ivars)
-    instance_reader = ivars.pop[:reader] if ivars.last.is_a?(Hash)
+    instance_reader = ivars.pop[:instance_reader] if ivars.last.is_a?(Hash)
 
     ivars.each do |ivar|
       self.class_eval <<-RUBY, __FILE__, __LINE__ + 1


### PR DESCRIPTION
Currently the instance reader is being blocked if :reader is set to false instead of :instance_reader when class_inheritable_reader is used. This causes unexpected results when an instance method had been defined but is overridden by this.
